### PR TITLE
add composer and encoder for sending CAN messages via USART

### DIFF
--- a/EHAL/src/ehal.c
+++ b/EHAL/src/ehal.c
@@ -48,8 +48,11 @@ void EHAL_Main_OutputProcess(void)
 {
 	EhalDio_CalcOutput();
 #if USART_USED
-	EhalUsart_SendTemperature();
+#if CAN_ANALYZER_MODE
 	EhalUsart_SendCan();
+#else
+	EhalUsart_SendTemperature();
+#endif
 #endif
 #if CAN_TX_USED
 	EhalCan_SendMessage();

--- a/EHAL/usart/inc/EhalUsart_OUT.h
+++ b/EHAL/usart/inc/EhalUsart_OUT.h
@@ -57,7 +57,7 @@ static inline void EhalUsart_OUT_InitUsart(void)
     USART_InitTypeDef USART_InitStructure;
 
     /* USARTx configuration ------------------------------------------------------*/
-    USART_InitStructure.USART_BaudRate   = 115200;
+    USART_InitStructure.USART_BaudRate   = 921600;
     USART_InitStructure.USART_WordLength = USART_WordLength_8b;
     USART_InitStructure.USART_StopBits   = USART_StopBits_1;
     USART_InitStructure.USART_Parity     = USART_Parity_No ;

--- a/EHAL/usart/src/EhalUsart.c
+++ b/EHAL/usart/src/EhalUsart.c
@@ -30,6 +30,11 @@
  * DEFINITION OF LOCAL MACROS/DEFINES
  * */
 
+#define PACKET_MAX_SIZE 22U
+#define STREAM_MAX_SIZE 50U
+#define COBS_MAX_CODE 	255U
+#define DELIMITER 		0U
+
 /*
  * DEFINITION OF LOCAL TYPES
  * */
@@ -38,7 +43,6 @@
  * DEFINITION OF LOCAL VARIABLES
  * */
 uint8_t EhalUsart_Temperature_Description_str[22] = "Current temperature: ";
-uint8_t EhalUsart_Can_Description_str[30] = "Counter of received CAN msg: ";
 uint8_t EhalUsart_Eol_str[2] = "\r\n";
 
 /*
@@ -48,6 +52,10 @@ uint8_t EhalUsart_Eol_str[2] = "\r\n";
 /*
  * DECLARATION OF LOCAL FUNCTIONS
  * */
+
+void composePacket(Rte_CanRx_tst* message, uint8_t* packet);
+
+size_t encodePacket(uint8_t* packet, size_t packetSize, uint8_t* encodedData);
 
 // Function to convert an integer to a string
 void intToString(int value, uint8_t *str);
@@ -95,23 +103,23 @@ void EhalUsart_SendTemperature(void)
 void EhalUsart_SendCan(void)
 {
 	Rte_CanRx_tst canRx;
+	uint8_t packet[PACKET_MAX_SIZE] = {0};
+	size_t encodedSize = 0;
+	uint8_t encodedData[STREAM_MAX_SIZE] = {0};
+
 	while (EhalUsart_IN_Can(&canRx) == TRUE)
 	{
-		for(int i=0; i<sizeof(EhalUsart_Can_Description_str); i++)
-		{
-			EhalUsart_OUT_SendData(EhalUsart_Can_Description_str[i]);
-		}
+		memset(packet, 0, sizeof(packet));
+		encodedSize = 0;
+		memset(encodedData, 0, sizeof(encodedData));
 
-		uint8_t EhalUsart_Can_MsgCounter_str[10];
-		intToString(canRx.msgCounter, EhalUsart_Can_MsgCounter_str);
-		for(int i=0; EhalUsart_Can_MsgCounter_str[i] != '\0'; i++)
-		{
-			EhalUsart_OUT_SendData(EhalUsart_Can_MsgCounter_str[i]);
-		}
+		composePacket(&canRx, packet);
 
-		for(int i=0; i<sizeof(EhalUsart_Eol_str); i++)
+		encodedSize = encodePacket(packet, sizeof(packet), encodedData);
+
+		for(int i = 0; i < encodedSize; i++)
 		{
-			EhalUsart_OUT_SendData(EhalUsart_Eol_str[i]);
+			EhalUsart_OUT_SendData(encodedData[i]);
 		}
 	}
 }
@@ -119,6 +127,98 @@ void EhalUsart_SendCan(void)
 /*
  * IMPLEMENTATION OF LOCAL FUNCTIONS
  * */
+
+void composePacket(Rte_CanRx_tst* message, uint8_t* packet)
+{
+	if((message == NULL) | (packet == NULL))
+	{
+		return;
+	}
+
+	uint16_t offset = 0;
+
+	memcpy(&packet[offset], &message->msgCounter, sizeof(message->msgCounter));
+	offset += sizeof(message->msgCounter);
+
+	memcpy(&packet[offset], &message->canRxMsg.StdId, sizeof(message->canRxMsg.StdId));
+	offset += sizeof(message->canRxMsg.StdId);
+
+	memcpy(&packet[offset], &message->canRxMsg.ExtId, sizeof(message->canRxMsg.ExtId));
+	offset += sizeof(message->canRxMsg.ExtId);
+
+	packet[offset++] = message->canRxMsg.IDE;
+	packet[offset++] = message->canRxMsg.RTR;
+	packet[offset++] = message->canRxMsg.DLC;
+
+	memcpy(&packet[offset], message->canRxMsg.Data, sizeof(message->canRxMsg.Data));
+	offset += sizeof(message->canRxMsg.Data);
+
+	packet[offset++] = message->canRxMsg.FMI;
+}
+
+size_t encodePacket(uint8_t* packet, size_t packetSize, uint8_t* encodedData)
+{
+	/* Examples
+	 *
+	 * index:  0  1  2  3
+	 * packet: 00
+	 * result: 01 01 00
+	 *
+	 * index:  0  1  2  3
+	 * packet: 00 55 44
+	 * result: 01 03 55 44 00
+	 *
+	 * index:  0  1  2  3
+	 * packet: 55 44
+	 * result: 03 55 44 00
+	 *
+	 * index:  0  1  2  3  4  5  6
+	 * packet: 55 44 00 33 22
+	 * result: 03 55 44 03 33 22 00
+	 */
+
+    if ((packet == NULL) || (encodedData == NULL) || (packetSize == 0))
+    {
+        return 0;
+    }
+
+    size_t writeIndex = 1;
+    size_t codeIndex = 0;
+    uint8_t code = 1;
+
+    for (uint16_t i = 0; i < packetSize; ++i)
+    {
+        if (packet[i] == 0)
+        {
+            // Write the code byte and reset for the next block
+            encodedData[codeIndex] = code;
+            codeIndex = writeIndex++;
+            code = 1;
+        }
+        else
+        {
+            // Copy non-zero byte to encoded data
+            encodedData[writeIndex++] = packet[i];
+            code++;
+
+            // If the block is full, write the code byte
+            if (code == COBS_MAX_CODE)
+            {
+                encodedData[codeIndex] = code;
+                codeIndex = writeIndex++;
+                code = 1;
+            }
+        }
+    }
+
+    // Write the final code byte
+    encodedData[codeIndex] = code;
+
+    // Append the COBS delimiter
+    encodedData[writeIndex] = DELIMITER;
+
+    return (writeIndex + 1); // Return the total size of the encoded data
+}
 
 // Function to convert an integer to a string
 void intToString(int value, uint8_t *str) {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Platform Software
-It provides a firmware foundation on which a different application runs. 
-- In the main branch: Temperature Indicator
-- In the can-analyzer branch: CAN Analyzer
+Depending on CAN_ANALYZER_MODE in system_macro, it provides a firmware foundation on which a different application runs. 
+- CAN_ANALYZER_MODE is FALSE: Temperature Indicator
+- CAN_ANALYZER_MODE is TRUE: CAN Analyzer
 
 ## Table of Contents
 [1. Temperature Indicator](#1-temperature-indicator)

--- a/inc/system_macro.h
+++ b/inc/system_macro.h
@@ -14,5 +14,6 @@
 #define PUSH_BUTTON_PE0_USED			TRUE
 #define CAN_TX_USED						FALSE
 #define CAN_RX_USED						TRUE
+#define CAN_ANALYZER_MODE				TRUE
 
 #endif


### PR DESCRIPTION
It adds the following functionalities to send CAN messages from CANAnalyzer to OBDScanner.
- composing a packet from a CAN message
- encoding a packet using COBS
- stop sending temperature values

It also changes the baud rate of USART from 115200 to 921600 to communicate with OBDScanner.
It also specifies CAN_ANALYZER_MODE in the readme file.